### PR TITLE
web > status: Fix pluralization of client socket connections

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -58,7 +58,7 @@ struct ConfigSettingsStruct{
   int refreshLogs;
   char hostname[50];
   bool connectedSocket[10];
-  int connectedClients;
+  uint8_t connectedClients;
   unsigned long socketTime;
   int tempOffset;
   bool webAuth;

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -752,17 +752,16 @@ void handleRoot() {
         const char* off = "Off";
 
         if (ConfigSettings.connectedClients > 0) {
-            if (ConfigSettings.connectedClients > 1) {
-                doc[connectedSocketStatus] = "Yes, " + String(ConfigSettings.connectedClients) + "connection";
-                doc[connectedSocket] = readableTime;
-            } else {
-                doc[connectedSocketStatus] = "Yes, " + String(ConfigSettings.connectedClients) + " connections";
-                doc[connectedSocket] = readableTime;
-            }
+            char str[32];
+            const uint8_t n = ConfigSettings.connectedClients;
+            snprintf(str, sizeof(str), "%s, %d connection%s", yes, n, (n > 1 ? "s" : ""));
+            doc[connectedSocketStatus] = str;
+            doc[connectedSocket] = readableTime;
         } else {
             doc[connectedSocketStatus] = no;
             doc[connectedSocket] = notConnected;
         }
+
         const char* operationalMode = "operationalMode";
         switch (ConfigSettings.coordinator_mode) {
             case COORDINATOR_MODE_USB:


### PR DESCRIPTION
Instead of changing `> 1` to `== 1`, use `yes` variable in consistent with the rest of the file.

Fixes:
- `Yes, 1 connections` to `Yes, 1 connection`.
- `Yes, 2 connection` to `Yes, 2 connections`.