### PR TITLE
to solve problems after: npx gulp

### DIFF
--- a/tools/webfilesbuilder/gulpfile.js
+++ b/tools/webfilesbuilder/gulpfile.js
@@ -64,7 +64,7 @@ function scripts() {
 			var filename = path.basename(file.path);
             var wstream = fs.createWriteStream("../../src/webh/" + filename + ".h");
             wstream.on("error", function(err) {
-                gutil.log(err);
+                console.log(err);
             });
 			var data = file.contents;
             wstream.write("#define " + filename.replace(/\.|-/g, "_") + "_len " + data.length + "\n");
@@ -98,7 +98,7 @@ function fonts() {
 			var filename = path.basename(file.path);
             var wstream = fs.createWriteStream("../../src/webh/" + filename + ".h");
             wstream.on("error", function(err) {
-                gutil.log(err);
+                console.log(err);
             });
 			var data = file.contents;
             wstream.write("#define " + filename.replace(/\.|-/g, "_") + "_len " + data.length + "\n");
@@ -132,7 +132,7 @@ function imgs() {
 			var filename = path.basename(file.path);
             var wstream = fs.createWriteStream("../../src/webh/" + filename + ".h");
             wstream.on("error", function(err) {
-                gutil.log(err);
+                console.log(err);
             });
 			var data = file.contents;
             wstream.write("#define " + filename.replace(/\.|-/g, "_") + "_len " + data.length + "\n");
@@ -166,7 +166,7 @@ function htmls() {
 			var filename = path.basename(file.path);
             var wstream = fs.createWriteStream("../../src/webh/" + filename + ".h");
             wstream.on("error", function(err) {
-                gutil.log(err);
+                console.log(err);
             });
 			var data = file.contents;
             wstream.write("#define " + filename.replace(/\.|-/g, "_") + "_len " + data.length + "\n");

--- a/tools/webfilesbuilder/gulpfile.js
+++ b/tools/webfilesbuilder/gulpfile.js
@@ -185,6 +185,11 @@ function htmls() {
         }));
 }
 
+var webh_dir = "../../src/webh/";
+if (!fs.existsSync(webh_dir)){
+    fs.mkdirSync(webh_dir);
+}
+
 const styleTasks = gulp.series(stylesConcat, styles);
 const scriptTasks = gulp.series(scriptsgz, scripts);
 const fontTasks = gulp.series(fontgz, fonts);


### PR DESCRIPTION
to solve problems after  ``npx gulp``

1. replace gutil.log to console.log
 
solving
```
[12:47:22] 'scripts' errored after 225 ms
[12:47:22] ReferenceError: gutil is not defined
```

2. create ``../../src/webh/`` if not exists

solving
```
[Error: ENOENT: no such file or directory, open '../../src/webh/required.css.gz.h'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '../../src/webh/required.css.gz.h'
}

```